### PR TITLE
Adding testing functionality using GoogleTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#Custom
+build/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,68 @@
-cmake_minimum_required(VERSION 3.10)
+# Specifies the minimum version of CMake required to process this file.
+# Using a range (3.50..4.0) ensures compatibility with modern features.
+cmake_minimum_required(VERSION 3.16..4.2)
 
+# Defines the project name and enables the C++ compiler.
 project(MicroMouse-Simulator LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 23)
+# Sets the C++ standard for the entire project to C++17.
+# This ensures consistency across all source files and compilers.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# --- Define Source Files ---
-set(APP_SOURCES src/Main.cpp src/MazeGen.cpp)
+# --- GoogleTest Integration (Conditional) ---
 
-# --- Create the Executable Target ---
-add_executable(mms ${APP_SOURCES})
+# This block executes only if the user configures CMake with -DBUILD_TESTING=ON.
+if(BUILD_TESTING)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        # Use a specific stable commit or tag (like release-1.14.0) for reliability.
+        GIT_TAG        52eb8108c5bdec04579160ae17225d66034bd723
+        # Recommended: Add DOWNLOAD_EXTRACT_TIMESTAMP TRUE for build robustness (CMP0135).
+    )
+    
+    # Makes the googletest targets (GTest::gtest, GTest::gtest_main, etc.) available 
+    # for linking in subsequent targets (like mms-test).
+    FetchContent_MakeAvailable(googletest)
+endif()
 
-# --- Configure Include Directories ---
+# --- Project Structure and Dependencies ---
 
-# Tell the compiler where to find header files.
-# By setting this as PUBLIC, any other target that links against 'my_app' 
-# will also get this include path (though typically the executable isn't linked to).
-target_include_directories(mms
+# Include the CTest module for test registration and management.
+include(CTest)
+
+# Add the 'tests' subdirectory, which contains its own CMakeLists.txt file.
+add_subdirectory(tests)
+
+# --- Core Logic Library Definition ---
+
+# Define the source files that contain the reusable application logic.
+set(CORE_SOURCES src/MazeGen.cpp)
+
+# Create a Static Library target. This bundles the core logic into a reusable 
+# library that can be linked by both the main executable and the test executable.
+add_library(mms-core STATIC ${CORE_SOURCES})
+
+# Configure Include Directories
+# Set the project's header directory as PUBLIC for the 'mms-core' library.
+target_include_directories(mms-core
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include 
 )
+# The PUBLIC keyword ensures that any target that links to 'mms-core' (like 'mms' 
+# and 'mms-test') automatically inherits this include path.
+
+# --- Main Executable Definition ---
+
+# Define the source file(s) for the application entry point.
+set(APP_SOURCES src/Main.cpp)
+
+# Create the main executable target
+add_executable(mms ${APP_SOURCES})
+
+# Link the core logic library to the main executable.
+# PRIVATE linkage means the executable uses the library internally, 
+# but downstream targets don't need to know about it (standard best practice).
+target_link_libraries(mms PRIVATE mms-core)

--- a/include/MazeGen.hpp
+++ b/include/MazeGen.hpp
@@ -1,8 +1,10 @@
 #pragma once
 #include <iostream>
 #include <string>
+#include <vector>
 
 class MazeGen {
 public:
   std::string generate(size_t rows, size_t columns);
+  static size_t exampleFunc();
 };

--- a/src/MazeGen.cpp
+++ b/src/MazeGen.cpp
@@ -11,3 +11,5 @@ std::string MazeGen::generate(size_t rows, size_t columns) {
   }
   return maze;
 }
+
+size_t MazeGen::exampleFunc() { return 42; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+# the test executable and related targets are only built when the user configures CMake with 
+# -DBUILD_TESTING=ON (as defined in the root CMakeLists.txt and CTest module).
+if(BUILD_TESTING)
+
+    # Creates the binary file (e.g., mms-test.exe) that will run all unit tests.
+    add_executable(mms-test MazeGen-Test.cpp)
+
+    # Connects the test executable to the necessary compiled code.
+    target_link_libraries(mms-test 
+        PRIVATE 
+            # Links to the GoogleTest main library, which provides the main() function 
+            # to run the tests and the testing framework itself.
+            GTest::gtest_main 
+            
+            # Links to your project's core logic library (defined in the root CMakeLists.txt).
+            # This is essential for calling the functions that we want test.
+            mms-core
+    )
+    
+    # Includes GoogleTest-specific CMake macros. This is necessary for gtest_discover_tests.
+    include(GoogleTest)
+    
+    # Searches the compiled executable (mms-test) for all defined tests (using TEST/TEST_F macros)
+    # and registers them with CTest. This allows you to run tests using the 'ctest' command.
+    gtest_discover_tests(mms-test)
+    
+endif()

--- a/tests/MazeGen-Test.cpp
+++ b/tests/MazeGen-Test.cpp
@@ -1,0 +1,4 @@
+#include "MazeGen.hpp"
+#include <gtest/gtest.h>
+
+TEST(TestTopic, TrivialEquality) { EXPECT_EQ(MazeGen::exampleFunc(), 42); }


### PR DESCRIPTION
### 1. Using CMake's FetchContent Module, automated the fetch and build of GoogleTest.
```cmake
# This block executes only if the user configures CMake with -DBUILD_TESTING=ON.
if(BUILD_TESTING)
    include(FetchContent)
    FetchContent_Declare(
        googletest
        GIT_REPOSITORY https://github.com/google/googletest.git
        # Use a specific stable commit or tag (like release-1.14.0) for reliability.
        GIT_TAG        52eb8108c5bdec04579160ae17225d66034bd723
        # Recommended: Add DOWNLOAD_EXTRACT_TIMESTAMP TRUE for build robustness (CMP0135).
    )

    # Makes the googletest targets (GTest::gtest, GTest::gtest_main, etc.) available 
    # for linking in subsequent targets (like mms-test).
    FetchContent_MakeAvailable(googletest)
endif()
```
### 2. Created a **tests** folder which will contain all the test files:
The CMakeLists.txt for the tests folder is:
```cmake
# the test executable and related targets are only built when the user configures CMake with 
# -DBUILD_TESTING=ON (as defined in the root CMakeLists.txt and CTest module).
if(BUILD_TESTING)

    # Creates the binary file (e.g., mms-test.exe) that will run all unit tests.
    add_executable(mms-test MazeGen-Test.cpp)

    # Connects the test executable to the necessary compiled code.
    target_link_libraries(mms-test 
        PRIVATE 
            # Links to the GoogleTest main library, which provides the main() function 
            # to run the tests and the testing framework itself.
            GTest::gtest_main 

            # Links to your project's core logic library (defined in the root CMakeLists.txt).
            # This is essential for calling the functions that we want test.
            mms-core
    )

    # Includes GoogleTest-specific CMake macros. This is necessary for gtest_discover_tests.
    include(GoogleTest)

    # Searches the compiled executable (mms-test) for all defined tests (using TEST/TEST_F macros)
    # and registers them with CTest. This allows you to run tests using the 'ctest' command.
    gtest_discover_tests(mms-test)

endif()
```
### 3. Added a basic test to check if GTest is working fine or not:
```cpp
//MazeGen.cpp
size_t MazeGen::exampleFunc() { return 42; }
```
```cpp
//MazeGen-Test.cpp
#include "MazeGen.hpp"
#include <gtest/gtest.h>

TEST(TestTopic, TrivialEquality) { EXPECT_EQ(MazeGen::exampleFunc(), 42); }
```