### PR TITLE
ci(pre-commit-config): Added pre-commit-hooks and CHANGELOG

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,60 @@
+---
 BasedOnStyle: LLVM
+ColumnLimit:  80
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+  AlignCompound:    true
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:     true
+AlignConsecutiveBitFields:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+  AlignCompound:    false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:     false
+AlignConsecutiveDeclarations:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+  AlignCompound:    false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:     false
+AlignConsecutiveMacros:
+  Enabled:          true
+  AcrossEmptyLines: false
+  AcrossComments:   false
+  AlignCompound:    false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:     false
+AlignConsecutiveShortCaseStatements:
+  Enabled:          false
+  AcrossEmptyLines: false
+  AcrossComments:   false
+  AlignCaseArrows:  false
+  AlignCaseColons:  false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AllowShortNamespacesOnASingleLine: false
+BreakBinaryOperations: RespectPrecedence
+BreakTemplateDeclarations: Yes
+IndentWidth:        4
+RemoveEmptyLinesInUnwrappedLines: true
+SpaceInEmptyBlock:  true
+SpacesBeforeTrailingComments: 2
+TabWidth:           4
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,54 @@
+---
+Checks: >-
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  bugprone-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  portability-*,
+
+  -bugprone-easily-swappable-parameters,
+  -modernize-use-nodiscard,
+  -readability-braces-around-statements,
+
+
+WarningsAsErrors: >-
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-security.*,
+  clang-analyzer-unix.*,
+  performance-move-const-arg,
+  performance-unnecessary-value-param,
+  readability-duplicate-include,
+
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+HeaderFilterRegex: '.*\.(c|cxx|cpp)$'
+ExcludeHeaderFilterRegex: ''
+FormatStyle:     none
+User:            Nyx4
+CheckOptions:
+  readability-identifier-naming.ConstantCase: UPPER_CASE
+  readability-identifier-naming.ClassConstantCase: UPPER_CASE
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassMethodCase: lower_case
+  readability-identifier-naming.ClassMemberCase: lower_case
+  readability-identifier-naming.FunctionCase: lower_case
+  readability-identifier-naming.VariableCase: lower_case
+  readability-function-size.StatementThreshold: 42
+  readability-function-size.NestingThreshold: 5
+SystemHeaders:   false
+UseColor:        true
+...

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,0 +1,1 @@
+# TODO: Add some checks to run on-push.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-#Custom
-build/
-.cache/
-
 # Prerequisites
 *.d
 
@@ -43,3 +39,13 @@ build/
 
 # debug information files
 *.dwo
+
+# CMake tempoorary files and folders
+build/
+.cache/
+Testing/
+CMakeFiles/
+Makefile
+compile_commands.json
+cmake_install.cmake
+CMakeCache.txt

--- a/.mdl.rb
+++ b/.mdl.rb
@@ -1,0 +1,4 @@
+all
+
+# set max line_lenght to 100
+rule 'MD013', :line_lenght => 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,107 @@
+fail_fast: false
+repos:
+  - repo: local
+    hooks:
+      - id: enable-testing
+        name: Enable testing configuration
+        entry: cmake
+        language: system
+        args: [-B build, -DBUILD_TESTING=ON]
+        pass_filenames: false
+        always_run: true
+
+      - id: build
+        name: Build the project using cmake
+        entry: cmake
+        language: system
+        args: [--build, build]
+        pass_filenames: false
+        always_run: true
+
+      - id: test
+        name: Test the project using ctest
+        entry: ctest
+        language: system
+        args: [--test-dir build, --output-on-failure]
+        pass_filenames: false
+        always_run: true
+
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: clang-format
+        args: []
+      - id: clang-tidy
+        args: []
+      - id: cppcheck
+        args: [src]
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.40.0
+    hooks:
+      - id: typos
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.10.0
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [pre-push]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
+
+  # unable to make https://github.com/markdownlint/markdownlint work via pre-commit
+  # so, calling system-installed mdl
+  - repo: local
+    hooks:
+      - id: markdownlint
+        name: Run markdownlint on your Markdown files
+        entry: mdl
+        args: [--style=.mdl.rb, --git-recurse, --ignore-front-matter]
+        language: system
+        files: \.(md|mdown|markdown)$
+        pass_filenames: true
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        name: "📁 filesystem/🤏 size · Prevent giant files from being committed"
+        args: [ '--maxkb=200' ]
+      - id: check-executables-have-shebangs
+        name: "📁 filesystem/⚙️ exec · Verify shebang presence"
+      - id: check-shebang-scripts-are-executable
+        name: "📁 filesystem/⚙️ exec · Verify script permissions"
+      - id: check-case-conflict
+        name: "📁 filesystem/📝 names · Check case sensitivity"
+      - id: check-illegal-windows-names
+        name: "📁 filesystem/📝 names · Validate Windows filenames"
+      - id: check-symlinks
+        name: "📁 filesystem/🔗 symlink · Check symlink validity"
+      - id: destroyed-symlinks
+        name: "📁 filesystem/🔗 symlink · Detect broken symlinks"
+      - id: check-json
+        name: "📁 filesystem/📃 data format · Load all json to verify syntax"
+      - id: check-toml
+        name: "📁 filesystem/📃 data format · Load all toml to verify syntax"
+      - id: check-xml
+        name: "📁 filesystem/📃 data format · Load all xml to verify syntax"
+      - id: check-yaml
+        name: "📁 filesystem/📃 data format · Load all yaml to verify syntax"
+      - id: forbid-submodules
+        name: "📁 filesystem/📦 submodules · Detect broken symlinks"
+      - id: mixed-line-ending
+        name: "🪟 windows/💔 use UNIX · Use LF as line ending on Windows 🥺"
+        args: [ '--fix=lf' ]
+      - id: check-ast
+        name: "🐍 python/🏴 syntax · Check files parse as valid python"
+      - id: check-docstring-first
+        name: "🐍 python/🏴 syntax · Check code is after the docstring"
+      - id: detect-private-key
+        name: "🐍 python/🔐 secrets · Checks for the existence of private keys"
+      - id: name-tests-test
+        name: "🐍 python/📝 names · Check test files are named correctly"
+        args: [ '--pytest-test-first' ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+    The following heading should be used
+        - Added
+        - Changed
+        - Deprecated
+        - Removed
+        - Fixed
+        - Security
+ -->
+
+## [unreleased]
+
+### Added
+- Added `.clang-tidy` that implements basic `Checks` like `cppcoreguidelines`, `modernize` and `readability` etc along with basic naming-conventions for Classes, Functions and Variables.
+- Added `CHANGELOG.md` to document all notable changes in a particular commit or release.
+- Added `.pre-commit-config.yaml` to automate formatting, linting, analysing, spell-correction, and other pesky tasks & checklist (install using `pre-commit install`).
+
+### Changed
+- Customized `.clang-format` for C++, away from pure LLVM coding-style. See [ClangFormatStyleOptions](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for more on what each does. tl;dr, it's just better? alignment and four-space tab. pro-tip: use empty line to separate two blocks of declarations.
+
+
+<!-- Here comes the `git diff` of each version -->
+<!-- SEE https://github.com/nyx-4/MicroProjects/blob/main/CHANGELOG.md?plain=1 for @nyx-4's CHANGELOG -->

--- a/cz.yaml
+++ b/cz.yaml
@@ -1,0 +1,8 @@
+---
+commitizen:
+  major_version_zero: true
+  name: cz_conventional_commits
+  tag_format: $version
+  update_changelog_on_bump: true
+  version: 0.0.1
+  version_scheme: semver2


### PR DESCRIPTION
 Added formatting and linting to pre-commit hooks, initialized CHANGELOG and added commitizen.

clang-format:   tab-width, better alignment, some QoL.
clang-tidy:     added linting checks and enforced naming scheme
gitignore:      ignored more files
markdownlint:   changed default line lenght to 100
CHANGELOG:      based on keepachangelog.com and semver.org v2.0
commitizen:     better commit messages, the easy way
pre-commit:     the main purpose of this commit, explained below:

## pre-commit:
enable-testing: Enable the testing configuration of cmake
build:          build/compile the project, needed for testing
test:           run the google-tests on the project automatically
clang-format:   check whether code complies with the formatting standards
clang-tidy:     provides framework for diagnosing and fixing errors
cppcheck:       provides code analysis to detect bugs, undefined behaviour, etc.
typos:          check for typos with minimum false-positive results
commitizen:     better commit messages, the automated way
actionlint:     lint GitHub actions for common CI/CD bugs and errors
markdownlint:   lint markdown files to comply with repo standards
pre-commit:     miscellaneous minor checks for trivial mistakes